### PR TITLE
Resolve conflicts on build.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,10 @@ script:
 after_success:
   - ldd capture/moloch-capture
   - fpm --verbose -s dir -t deb -n moloch -v v0.17.1+JM --template-scripts --after-install "release/afterinstall.sh" --url "https://github.com/jpvlsmv/moloch" --description "Moloch full capture JFM" -d libwww-perl -d libjson-perl -d ethtool -C $HOME data/moloch
+  - find / -xdev -name '*.deb' -ls
   - aws --region=us-east-1 s3 cp /tmp/moloch*.deb s3://content.iegrec.org/moloch/
   - tar cfz $HOME/moloch.tgz -C $HOME data
   - aws --region=us-east-1 s3 cp $HOME/moloch.tgz s3://content.iegrec.org/moloch/build.tgz
+addons:
+  artifacts: true
+    s3_region: "us-east-1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - fpm_description= "Moloch Full Packet System"
   - iteration= 1
 addons:
+  artifacts: true
   apt:
     packages:
     -  wget
@@ -71,5 +72,3 @@ after_success:
   - aws --region=us-east-1 s3 cp /tmp/moloch*.deb s3://content.iegrec.org/moloch/
   - tar cfz $HOME/moloch.tgz -C $HOME data
   - aws --region=us-east-1 s3 cp $HOME/moloch.tgz s3://content.iegrec.org/moloch/build.tgz
-addons:
-  artifacts: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_cache:
   - cp /dev/null $HOME/build/jpvlsmv/moloch/thirdparty/libpcap-1.7.4/config.log
 script:
   - ./configure --prefix=/data/moloch --with-yara=thirdparty/yara-$yara_version
-  - make
+  - make CFLAGS=-pg
   - ./configure --prefix=$HOME/data/moloch --with-yara=thirdparty/yara-$yara_version
   - make install
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
     -  g++
     -  flex
     -  bison
+    -  automake
     -  zlib1g-dev
     -  libffi-dev
     -  gettext

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,26 +19,26 @@ env:
 addons:
   apt:
     packages:
-    -  wget 
-    -  curl 
-    -  libpcre3-dev 
-    -  uuid-dev 
-    -  libmagic-dev 
-    -  pkg-config 
-    -  g++ 
-    -  flex 
-    -  bison 
-    -  zlib1g-dev 
-    -  libffi-dev 
-    -  gettext 
-    -  libgeoip-dev 
-    -  make 
-    -  libjson-perl 
-    -  libbz2-dev 
-    -  libwww-perl 
-    -  libpng-dev 
-    -  xz-utils 
-    -  libffi-dev 
+    -  wget
+    -  curl
+    -  libpcre3-dev
+    -  uuid-dev
+    -  libmagic-dev
+    -  pkg-config
+    -  g++
+    -  flex
+    -  bison
+    -  zlib1g-dev
+    -  libffi-dev
+    -  gettext
+    -  libgeoip-dev
+    -  make
+    -  libjson-perl
+    -  libbz2-dev
+    -  libwww-perl
+    -  libpng-dev
+    -  xz-utils
+    -  libffi-dev
     -  libssl-dev
     -  liblua5.2-dev
     -  libdaq-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,6 @@ script:
 after_success:
   - ldd capture/moloch-capture
   - tar cfz $HOME/moloch.tgz -C $HOME data
+  - fpm -s dir -t deb -n moloch -v v0.17.1+JM --template-scripts --after-install "moloch/release/afterinstall.sh" --url \"https://github.com/jpvlsmv/moloch\" --description \"Moloch full capture JFM\" -d libwww-perl -d libjson-perl -d ethtool -C $HOME data/moloch
   - aws --region=us-east-1 s3 cp $HOME/moloch.tgz s3://content.iegrec.org/moloch/build.tgz
+  - aws --region=us-east-1 s3 cp $HOME/moloch*deb s3://content.iegrec.org/moloch/

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,6 @@ script:
 after_success:
   - ldd capture/moloch-capture
   - tar cfz $HOME/moloch.tgz -C $HOME data
-  - fpm --verbose -s dir -t deb -n moloch -v v0.17.1+JM --template-scripts --after-install "moloch/release/afterinstall.sh" --url "https://github.com/jpvlsmv/moloch" --description "Moloch full capture JFM" -d libwww-perl -d libjson-perl -d ethtool -C $HOME data/moloch
+  - fpm --verbose -s dir -t deb -n moloch -v v0.17.1+JM --template-scripts --after-install "release/afterinstall.sh" --url "https://github.com/jpvlsmv/moloch" --description "Moloch full capture JFM" -d libwww-perl -d libjson-perl -d ethtool -C $HOME data/moloch
   - aws --region=us-east-1 s3 cp $HOME/moloch.tgz s3://content.iegrec.org/moloch/build.tgz
   - aws --region=us-east-1 s3 cp $HOME/moloch*deb s3://content.iegrec.org/moloch/

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,6 @@ script:
 after_success:
   - ldd capture/moloch-capture
   - tar cfz $HOME/moloch.tgz -C $HOME data
-  - fpm -s dir -t deb -n moloch -v v0.17.1+JM --template-scripts --after-install "moloch/release/afterinstall.sh" --url \"https://github.com/jpvlsmv/moloch\" --description \"Moloch full capture JFM\" -d libwww-perl -d libjson-perl -d ethtool -C $HOME data/moloch
+  - fpm --verbose -s dir -t deb -n moloch -v v0.17.1+JM --template-scripts --after-install "moloch/release/afterinstall.sh" --url "https://github.com/jpvlsmv/moloch" --description "Moloch full capture JFM" -d libwww-perl -d libjson-perl -d ethtool -C $HOME data/moloch
   - aws --region=us-east-1 s3 cp $HOME/moloch.tgz s3://content.iegrec.org/moloch/build.tgz
   - aws --region=us-east-1 s3 cp $HOME/moloch*deb s3://content.iegrec.org/moloch/

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - make install
 after_success:
   - ldd capture/moloch-capture
-  - tar cfz $HOME/moloch.tgz -C $HOME data
   - fpm --verbose -s dir -t deb -n moloch -v v0.17.1+JM --template-scripts --after-install "release/afterinstall.sh" --url "https://github.com/jpvlsmv/moloch" --description "Moloch full capture JFM" -d libwww-perl -d libjson-perl -d ethtool -C $HOME data/moloch
+  - aws --region=us-east-1 s3 cp /tmp/moloch*.deb s3://content.iegrec.org/moloch/
+  - tar cfz $HOME/moloch.tgz -C $HOME data
   - aws --region=us-east-1 s3 cp $HOME/moloch.tgz s3://content.iegrec.org/moloch/build.tgz
-  - aws --region=us-east-1 s3 cp $HOME/moloch*deb s3://content.iegrec.org/moloch/

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
 after_success:
   - ldd capture/moloch-capture
   - fpm --verbose -s dir -t deb -n moloch -v v0.17.1+JM --template-scripts --after-install "release/afterinstall.sh" --url "https://github.com/jpvlsmv/moloch" --description "Moloch full capture JFM" -d libwww-perl -d libjson-perl -d ethtool -C $HOME data/moloch
-  - find / -xdev -name '*.deb' -ls
-  - aws --region=us-east-1 s3 cp /tmp/moloch*.deb s3://content.iegrec.org/moloch/
+#  - find / -xdev -name '*.deb' -ls
+  - aws --region=us-east-1 s3 cp ~/build/jpvlamv/moloch/moloch*.deb s3://content.iegrec.org/moloch/
   - tar cfz $HOME/moloch.tgz -C $HOME data
   - aws --region=us-east-1 s3 cp $HOME/moloch.tgz s3://content.iegrec.org/moloch/build.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,4 +73,3 @@ after_success:
   - aws --region=us-east-1 s3 cp $HOME/moloch.tgz s3://content.iegrec.org/moloch/build.tgz
 addons:
   artifacts: true
-    s3_region: "us-east-1"

--- a/release/build.yml
+++ b/release/build.yml
@@ -1,6 +1,10 @@
----
-# Requires running: ansible-galaxy install rvm_io.rvm1-ruby
-# To just rebuild: ansible-playbook --private-key=~/.vagrant.d/insecure_private_key -u vagrant -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory build.yml -t rebuild
+# Requires running: ansible-galaxy install -p `pwd`/roles rvm_io.ruby
+# and set ANSIBLE_ROLES_PATH=`pwd`/roles
+# NOTE: Vagrant 1.9.0 works, 1.9.2 has issues on some platforms
+# vagrant up
+# To rebuild either: vagrant provision
+#  OR
+# ansible-playbook --private-key=~/.vagrant.d/insecure_private_key -u vagrant -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory build.yml -t rebuild
 - hosts: all
   become: true
   become_method: sudo
@@ -77,6 +81,10 @@
             - libselinux-python
             - rpm-build
             - pfring
+            - ruby
+            - ruby-devel
+            - rubygems
+            - readline-devel
 
       # Block end
       when: ansible_distribution=='CentOS'
@@ -112,6 +120,8 @@
             - libffi-dev
             - libssl-dev
             - pfring
+            - ruby
+            - ruby-dev
 
       # Block end
       when: ansible_distribution == 'Ubuntu'
@@ -122,13 +132,19 @@
 
 # Install ruby
   roles:
-    - {role: rvm_io.rvm1-ruby}
+    - {role: rvm_io.ruby,
+      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
+      }
 
 # Tasks after roles
   tasks:
-    - name: install fpm
-      gem: name=fpm user_install=no state=latest executable=/usr/local/bin/gem
+    - name: install fpm from /usr/bin
+      gem: name=fpm user_install=no state=latest executable='/usr/bin/gem'
+      when: not ( ansible_distribution == "CentOS" and ansible_distribution_major_version == "6" )
 
+    - name: install fpm from RVM's area
+      gem: name=fpm user_install=no state=latest executable='/usr/local/rvm/rubies/ruby-1.9.3-p551/lib/ruby/gems/1.9.1/wrappers/gem'
+      when:     ( ansible_distribution == "CentOS" and ansible_distribution_major_version == "6" )
 
 # Prepare prereqs
     - name: Download Packages
@@ -344,7 +360,7 @@
       - name: fpm centos
         shell: bash -lc "{{item}}"
         with_items:
-          - fpm -s dir -t rpm -n {{moloch_name}} -v {{moloch_version}} --iteration {{iteration}} --template-scripts --after-install "{{moloch_name}}/release/afterinstall.sh" --url \"{{fpm_url}}\" --description \"{{fpm_description}}\" -d perl-libwww-perl -d perl-JSON -d ethtool /data/{{moloch_name}}
+          - /usr/bin/env fpm -s dir -t rpm -n {{moloch_name}} -v {{moloch_version}} --iteration {{iteration}} --template-scripts --after-install "{{moloch_name}}/release/afterinstall.sh" --url \"{{fpm_url}}\" --description \"{{fpm_description}}\" -d perl-libwww-perl -d perl-JSON -d ethtool /data/{{moloch_name}}
 
       - name: copy centos back
         fetch: src={{moloch_name}}-{{moloch_version}}-{{iteration}}.x86_64.rpm dest=./builds


### PR DESCRIPTION
Revise Ansible configuration to successfully build .deb and .rpm for the 4 platforms.

* Install the RVM role only for this build's use (does not require root)
* Centos-6 is the only one that needs to upgrade Ruby (ships with 1.8, fpm requires >1.9)
* The Ruby development packages are required to build the native code for fpm

With this, `vagrant up` (or `vagrant provision`) successfully creates the packages.